### PR TITLE
pass enabled_site_setting to Auth::OpenIdAuthenticator

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -7,7 +7,7 @@ enabled_site_setting :ubuntu_login_enabled
 
 auth_provider :title => 'with Ubuntu',
               :enabled_setting => 'ubuntu_login_enabled',
-              :authenticator => Auth::OpenIdAuthenticator.new('ubuntu','https://login.ubuntu.com', trusted: true),
+              :authenticator => Auth::OpenIdAuthenticator.new('ubuntu','https://login.ubuntu.com', :ubuntu_login_enabled, trusted: true),
               :message => 'Authenticating with Ubuntu (make sure pop up blockers are not enabled)',
               :frame_width => 1000,   # the frame size used for the pop up window, overrides default
               :frame_height => 800


### PR DESCRIPTION
This is needed so that .enabled? works later. 

commit eda1462b3b8f57aace0c49b1d64edfcf3d1f45b2 added this argument and the code that uses it.

I believe this may address issue #1.